### PR TITLE
Make sure ActiveRecord isn't loaded when other ORM/ODM is use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle/
+.idea/
 .yardoc
 .DS_Store
 Gemfile.lock

--- a/lib/spreadsheet_architect/action_controller_renderers.rb
+++ b/lib/spreadsheet_architect/action_controller_renderers.rb
@@ -2,7 +2,7 @@ if defined? ActionController
 
   ['csv','ods','xlsx'].each do |format|
     ActionController::Renderers.add(format.to_sym) do |data, options|
-      if data.is_a?(ActiveRecord::Relation)
+      if defined?(ActiveRecord) && data.is_a?(ActiveRecord::Relation)
         options[:filename] = data.klass.name.pluralize
         data = data.send("to_#{format}")
       end


### PR DESCRIPTION
Our application is leveraging Mongoid and obvious does not require ActiveRecord. When making checking for ActiveRecord::Relation an error is thrown when ActiveRecord is not present, this alleviates that.