### PR TITLE
added option :fixed_top_left to prevent the header row and the first …

### DIFF
--- a/examples/fixed_top_left.rb
+++ b/examples/fixed_top_left.rb
@@ -1,0 +1,67 @@
+# rake install:local from root
+require 'spreadsheet_architect'
+
+base_spreadsheet_styles =
+      {
+        header_style: {
+          background_color: "663496",
+          color:            "FFFFFF",
+          align:            :center,
+          font_name:        'Arial',
+          font_size:        20,
+          bold:             true,
+          italic:           false,
+          underline:        false
+        },
+        row_style:    {
+          background_color: nil,
+          color:            "000000",
+          align:            :left,
+          font_name:        'Arial',
+          font_size:        18,
+          bold:             false,
+          italic:           false,
+          underline:        false,
+          format_code:      nil
+        },
+        # column_styles:      [],
+        # column_types:       [], # Valid types for XLSX are :string, :integer, :float, :boolean, nil = auto determine.
+        # column_widths:      [], # use nil for auto-fil
+      }
+
+
+headers      = %w[one two three four five six seven eight nine ten]
+test_data    = []
+
+100.times do |row|
+  row = []
+  10.times do |col|
+    row << col
+  end
+  test_data << row
+end
+
+
+options =
+ {
+    headers: headers,
+    data: test_data,
+  }.merge(base_spreadsheet_styles)
+
+fixed_options = options.dup
+fixed_options[:sheet_name] = 'Fixed'
+fixed_options[:header_style][:fixed_top_left] = true
+
+package = SpreadsheetArchitect.to_axlsx_package(fixed_options)
+
+
+not_fixed_options = options.dup
+not_fixed_options[:sheet_name] = 'Not Fixed'
+not_fixed_options[:header_style][:fixed_top_left] = false
+
+package = SpreadsheetArchitect.to_axlsx_package(not_fixed_options, package)
+
+
+File.open("fixed_top_left.xlsx",'w+b') do |f|
+  f.write package.to_stream.read
+end

--- a/lib/spreadsheet_architect/class_methods/xlsx.rb
+++ b/lib/spreadsheet_architect/class_methods/xlsx.rb
@@ -40,7 +40,7 @@ module SpreadsheetArchitect
 
             sheet.add_row header_row, style: header_style_index
 
-            if options[:header_style][:fixed_top_left]
+            if options[:header_style] && options[:header_style][:fixed_top_left]
               # Fix the position of the first row and column
               # so that they do not scroll.
               sheet.sheet_view.pane do |pane|

--- a/lib/spreadsheet_architect/class_methods/xlsx.rb
+++ b/lib/spreadsheet_architect/class_methods/xlsx.rb
@@ -12,7 +12,7 @@ module SpreadsheetArchitect
     def to_axlsx_package(opts={}, package=nil)
       opts = SpreadsheetArchitect::Utils.get_options(opts, self)
       options = SpreadsheetArchitect::Utils.get_cell_data(opts, self)
-    
+
       header_style = SpreadsheetArchitect::Utils::XLSX.convert_styles_to_axlsx(options[:header_style])
       row_style = SpreadsheetArchitect::Utils::XLSX.convert_styles_to_axlsx(options[:row_style])
 
@@ -40,12 +40,24 @@ module SpreadsheetArchitect
 
             sheet.add_row header_row, style: header_style_index
 
+            if options[:header_style][:fixed_top_left]
+              # Fix the position of the first row and column
+              # so that they do not scroll.
+              sheet.sheet_view.pane do |pane|
+                pane.top_left_cell  = "B2"
+                pane.state          = :frozen_split
+                pane.y_split        = 1
+                pane.x_split        = 1
+                pane.active_pane    = :bottom_right
+              end
+            end
+
             if options[:conditional_row_styles]
               conditional_styles_for_row = SpreadsheetArchitect::Utils::XLSX.conditional_styles_for_row(options[:conditional_row_styles], row_index, header_row)
-              
+
               unless conditional_styles_for_row.empty?
                 sheet.add_style(
-                  "#{SpreadsheetArchitect::Utils::XLSX::COL_NAMES.first}#{row_index+1}:#{SpreadsheetArchitect::Utils::XLSX::COL_NAMES[max_row_length-1]}#{row_index+1}", 
+                  "#{SpreadsheetArchitect::Utils::XLSX::COL_NAMES.first}#{row_index+1}:#{SpreadsheetArchitect::Utils::XLSX::COL_NAMES[max_row_length-1]}#{row_index+1}",
                   SpreadsheetArchitect::Utils::XLSX.convert_styles_to_axlsx(conditional_styles_for_row)
                 )
               end
@@ -103,10 +115,10 @@ module SpreadsheetArchitect
 
           if options[:conditional_row_styles]
             conditional_styles_for_row = SpreadsheetArchitect::Utils::XLSX.conditional_styles_for_row(options[:conditional_row_styles], row_index, row_data)
-            
+
             unless conditional_styles_for_row.empty?
               sheet.add_style(
-                "#{SpreadsheetArchitect::Utils::XLSX::COL_NAMES.first}#{row_index+1}:#{SpreadsheetArchitect::Utils::XLSX::COL_NAMES[max_row_length-1]}#{row_index+1}", 
+                "#{SpreadsheetArchitect::Utils::XLSX::COL_NAMES.first}#{row_index+1}:#{SpreadsheetArchitect::Utils::XLSX::COL_NAMES[max_row_length-1]}#{row_index+1}",
                 SpreadsheetArchitect::Utils::XLSX.convert_styles_to_axlsx(conditional_styles_for_row)
               )
             end


### PR DESCRIPTION
…column from scrolling in an xlsx file.  This new option is part of the :header_style option hash.

This is the basic idea. It works.  You may have a better feel for the actual style name to use that fits better within your sense of an API element.

Solves #25 