### PR TITLE
 Add license to gemspec for easier automatic discovery

### DIFF
--- a/spreadsheet_architect.gemspec
+++ b/spreadsheet_architect.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   
   s.summary     = "Spreadsheet Architect is a library that allows you to create XLSX, ODS, or CSV spreadsheets easily from ActiveRecord relations, Plain Ruby classes, or predefined data."
   s.description = s.summary 
+  s.license     = 'MIT'
 
   s.files = Dir.glob("{lib/**/*}") + %w{ LICENSE README.md Rakefile CHANGELOG.md }
   s.test_files  = Dir.glob("{test/**/*}")


### PR DESCRIPTION
The LICENSE file already defines this gem as MIT, but this adds that info to the gemspec as well.