### PR TITLE
Escape formulas in XLSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ See this file for more details: [test/unit/multi_sheet_test.rb](./test/unit/mult
 |**freeze_headers**<br>*Boolean*||Make all header rows frozen/fixed so they do not scroll.|
 |**freeze**<br>*Hash*|`{rows: (1..4), columns: :all}`|Make all specified rows and columns frozen/fixed so they do not scroll.|
 |**skip_defaults**<br>*Boolean*|`false`|Removes defaults and default styles. Particularily useful for heavily customized spreadsheets where the default styles get in the way.|
+|**escape_formulas**<br>*Boolean* or *array* of booleans|`true`|Escapes formulas. Pass a single boolean to apply to all cells, or an array of booleans to control column-by-column. Advisable to be set true when involved with untrusted user input. See [an example of the underlying functionality](https://github.com/caxlsx/caxlsx/blob/master/examples/escape_formula_example.md).|
 
 ## `to_axlsx_spreadsheet(options={}, axlsx_package_to_join=nil)`
 Same options as `to_xlsx`

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ See this file for more details: [test/unit/multi_sheet_test.rb](./test/unit/mult
 |**freeze_headers**<br>*Boolean*||Make all header rows frozen/fixed so they do not scroll.|
 |**freeze**<br>*Hash*|`{rows: (1..4), columns: :all}`|Make all specified rows and columns frozen/fixed so they do not scroll.|
 |**skip_defaults**<br>*Boolean*|`false`|Removes defaults and default styles. Particularily useful for heavily customized spreadsheets where the default styles get in the way.|
-|**escape_formulas**<br>*Boolean* or *array* of booleans|`true`|Escapes formulas. Pass a single boolean to apply to all cells, or an array of booleans to control column-by-column. Advisable to be set true when involved with untrusted user input. See [an example of the underlying functionality](https://github.com/caxlsx/caxlsx/blob/master/examples/escape_formula_example.md).|
+|**escape_formulas**<br>*Boolean* or *Array*|`true`|Escapes formulas. Pass a single boolean to apply to all cells, or an array of booleans to control column-by-column. Advisable to be set true when involved with untrusted user input. See [an example of the underlying functionality](https://github.com/caxlsx/caxlsx/blob/master/examples/escape_formula_example.md).|
 
 ## `to_axlsx_spreadsheet(options={}, axlsx_package_to_join=nil)`
 Same options as `to_xlsx`

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ See this file for more details: [test/unit/multi_sheet_test.rb](./test/unit/mult
 |**freeze_headers**<br>*Boolean*||Make all header rows frozen/fixed so they do not scroll.|
 |**freeze**<br>*Hash*|`{rows: (1..4), columns: :all}`|Make all specified rows and columns frozen/fixed so they do not scroll.|
 |**skip_defaults**<br>*Boolean*|`false`|Removes defaults and default styles. Particularily useful for heavily customized spreadsheets where the default styles get in the way.|
-|**escape_formulas**<br>*Boolean* or *Array*|`true`|Escapes formulas. Pass a single boolean to apply to all cells, or an array of booleans to control column-by-column. Advisable to be set true when involved with untrusted user input. See [an example of the underlying functionality](https://github.com/caxlsx/caxlsx/blob/master/examples/escape_formula_example.md).|
+|**escape_formulas**<br>*Boolean* or *Array*|`true`|Pass a single boolean to apply to all cells, or an array of booleans to control column-by-column. Advisable to be set true when involved with untrusted user input. See [an example of the underlying functionality](https://github.com/caxlsx/caxlsx/blob/master/examples/escape_formula_example.md). NOTE: Header row cells are not escaped. |
 
 ## `to_axlsx_spreadsheet(options={}, axlsx_package_to_join=nil)`
 Same options as `to_xlsx`

--- a/lib/spreadsheet_architect/class_methods/xlsx.rb
+++ b/lib/spreadsheet_architect/class_methods/xlsx.rb
@@ -104,7 +104,7 @@ module SpreadsheetArchitect
             end
           end
 
-          sheet.add_row row_data, style: styles, types: types
+          sheet.add_row row_data, style: styles, types: types, escape_formulas: options[:escape_formulas]
 
           if options[:conditional_row_styles]
             options[:conditional_row_styles] = SpreadsheetArchitect::Utils.hash_array_symbolize_keys(options[:conditional_row_styles])

--- a/lib/spreadsheet_architect/class_methods/xlsx.rb
+++ b/lib/spreadsheet_architect/class_methods/xlsx.rb
@@ -43,7 +43,7 @@ module SpreadsheetArchitect
               end
             end
 
-            sheet.add_row header_row, style: header_style_index
+            sheet.add_row header_row, style: header_style_index, escape_formulas: true
 
             if options[:conditional_row_styles]
               conditional_styles_for_row = SpreadsheetArchitect::Utils::XLSX.conditional_styles_for_row(options[:conditional_row_styles], row_index, header_row)

--- a/lib/spreadsheet_architect/class_methods/xlsx.rb
+++ b/lib/spreadsheet_architect/class_methods/xlsx.rb
@@ -43,7 +43,7 @@ module SpreadsheetArchitect
               end
             end
 
-            sheet.add_row header_row, style: header_style_index, escape_formulas: true
+            sheet.add_row header_row, style: header_style_index
 
             if options[:conditional_row_styles]
               conditional_styles_for_row = SpreadsheetArchitect::Utils::XLSX.conditional_styles_for_row(options[:conditional_row_styles], row_index, header_row)

--- a/lib/spreadsheet_architect/utils.rb
+++ b/lib/spreadsheet_architect/utils.rb
@@ -294,6 +294,7 @@ module SpreadsheetArchitect
       row_style: Hash,
       sheet_name: String,
       spreadsheet_columns: [Proc, Symbol, String],
+      escape_formulas: [TrueClass, FalseClass, Array]
     }.freeze
 
 

--- a/lib/spreadsheet_architect/utils.rb
+++ b/lib/spreadsheet_architect/utils.rb
@@ -150,6 +150,10 @@ module SpreadsheetArchitect
         end
       end
 
+      unless options[:escape_formulas].class.in?[TrueClass, FalseClass, Array]
+        options[:escape_formulas] = true
+      end
+
       return options
     end
 

--- a/lib/spreadsheet_architect/utils.rb
+++ b/lib/spreadsheet_architect/utils.rb
@@ -150,7 +150,7 @@ module SpreadsheetArchitect
         end
       end
 
-      unless options[:escape_formulas].class.in?([TrueClass, FalseClass, Array])
+      if options[:escape_formulas].nil?
         options[:escape_formulas] = true
       end
 

--- a/lib/spreadsheet_architect/utils.rb
+++ b/lib/spreadsheet_architect/utils.rb
@@ -150,7 +150,7 @@ module SpreadsheetArchitect
         end
       end
 
-      unless options[:escape_formulas].class.in?[TrueClass, FalseClass, Array]
+      unless options[:escape_formulas].class.in?([TrueClass, FalseClass, Array])
         options[:escape_formulas] = true
       end
 

--- a/test/unit/utils_test.rb
+++ b/test/unit/utils_test.rb
@@ -97,17 +97,14 @@ class UtilsTest < ActiveSupport::TestCase
     assert_equal klass.get_options({sheet_name: false}, Post)[:sheet_name], 'Posts'
 
     ### removes default styles
-    assert_equal klass.get_options({skip_defaults: true}, SpreadsheetArchitect), {skip_defaults: true, sheet_name: "Sheet1"}
-    assert_equal klass.get_options({skip_defaults: true}, Post), {skip_defaults: true, sheet_name: "Posts"}
+    assert_equal klass.get_options({skip_defaults: true}, SpreadsheetArchitect), {skip_defaults: true, sheet_name: "Sheet1", escape_formulas: true}
+    assert_equal klass.get_options({skip_defaults: true}, Post), {skip_defaults: true, sheet_name: "Posts", escape_formulas: true}
 
-    assert_not_equal klass.get_options({skip_defaults: false}, SpreadsheetArchitect), {skip_defaults: true, sheet_name: "Sheet1"}
-    assert_not_equal klass.get_options({skip_defaults: false}, Post), {skip_defaults: true, sheet_name: "Posts"}
+    assert_not_equal klass.get_options({skip_defaults: false}, SpreadsheetArchitect), {skip_defaults: true, sheet_name: "Sheet1", escape_formulas: true}
+    assert_not_equal klass.get_options({skip_defaults: false}, Post), {skip_defaults: true, sheet_name: "Posts", escape_formulas: true}
 
-    ### sets :escape_formulas if not given in a valid way
+    ### sets :escape_formulas if not given
     assert_equal klass.get_options({}, SpreadsheetArchitect)[:escape_formulas], true
-    assert_equal klass.get_options({escape_formulas: true}, SpreadsheetArchitect)[:escape_formulas], true
-    assert_equal klass.get_options({escape_formulas: false}, SpreadsheetArchitect)[:escape_formulas], false
-    assert_equal klass.get_options({escape_formulas: [true, false]}, SpreadsheetArchitect)[:escape_formulas], [true, false]
   end
   
   test "convert_styles_to_ods" do

--- a/test/unit/utils_test.rb
+++ b/test/unit/utils_test.rb
@@ -102,6 +102,12 @@ class UtilsTest < ActiveSupport::TestCase
 
     assert_not_equal klass.get_options({skip_defaults: false}, SpreadsheetArchitect), {skip_defaults: true, sheet_name: "Sheet1"}
     assert_not_equal klass.get_options({skip_defaults: false}, Post), {skip_defaults: true, sheet_name: "Posts"}
+
+    ### sets :escape_formulas if not given in a valid way
+    assert_equal klass.get_options({}, SpreadsheetArchitect)[:escape_formulas], true
+    assert_equal klass.get_options({escape_formulas: true}, SpreadsheetArchitect)[:escape_formulas], true
+    assert_equal klass.get_options({escape_formulas: false}, SpreadsheetArchitect)[:escape_formulas], false
+    assert_equal klass.get_options({escape_formulas: [true, false]}, SpreadsheetArchitect)[:escape_formulas], [true, false]
   end
   
   test "convert_styles_to_ods" do


### PR DESCRIPTION
This adds an `escape_formulas` option to the XLSX generating methods in order to avoid formula injection when generating XLSX. The header row is additionally always escaped.

Usage:

```ruby
SpreadsheetArchitect.to_xlsx(data: [["=1+1"]], escape_formulas: true) #default
SpreadsheetArchitect.to_xlsx(data: [["Safe"]], escape_formulas: false)
SpreadsheetArchitect.to_xlsx(data: [["=1+1", "Safe"]], escape_formulas: [true, false])
```