### PR TITLE
Dont add blank header row when headers: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
   - Add option `use_zero_based_row_index: true` (Default `false`) which allows you to use zero-based row indexes instead of the default 1-based row indexes. Recomended to set this option for the whole project. The original reason it was designed to be 1-based is because spreadsheet row numbers literally start with 1. However this tends to be unituitive for the developer because columns use zero based indexes because they use letter-based notation instead.
   - Improve argument handling for freeze option and add support for all Axlsx supported options for panes using the `:freeze` hash. See test case for example (./test/unit/xlsx_freeze_test.rb)
   - Improve exceptions and messages regarding invalid ranges
+  - For `to_xlsx`, dont add empty header row when `header: true`
 
 - **4.2.0** - May 27, 2021 - [View Diff](https://github.com/westonganger/spreadsheet_architect/compare/v4.1.0...v4.2.0)
   - Add option `:skip_defaults` which removes the defaults and default styles. Particularily useful for heavily customized spreadsheets where the default styles get in the way.

--- a/lib/spreadsheet_architect/utils.rb
+++ b/lib/spreadsheet_architect/utils.rb
@@ -10,7 +10,9 @@ module SpreadsheetArchitect
       if options[:headers] == true
         headers = []
 
-        if !options[:data]
+        if options[:data]
+          headers = false
+        else
           needs_headers = true
         end
       elsif options[:headers].is_a?(Array)

--- a/test/unit/utils_test.rb
+++ b/test/unit/utils_test.rb
@@ -40,7 +40,7 @@ class UtilsTest < ActiveSupport::TestCase
 
     ### using Data option
     output = klass.get_cell_data(@options.merge(headers: true), SpreadsheetArchitect)
-    assert_equal [[]], output[:headers]
+    assert_equal false, output[:headers]
 
     output = klass.get_cell_data(@options.merge(headers: false), SpreadsheetArchitect)
     assert_equal false, output[:headers]


### PR DESCRIPTION
Changes for `to_xlsx` when using `headers: true` or `SpreadsheetArchitect.default_options[:headers] = true` combined with the `data:` option

Previous Behaviour: Adds a blank header row
New Behaviour: Skips adding the header row