### PR TITLE
Allow enumerators

### DIFF
--- a/lib/spreadsheet_architect/utils.rb
+++ b/lib/spreadsheet_architect/utils.rb
@@ -257,7 +257,7 @@ module SpreadsheetArchitect
       freeze: Hash,
       headers: [TrueClass, FalseClass, Array],
       header_style: Hash,
-      instances: Array,
+      instances: [Array, Enumerator],
       merges: Array,
       range_styles: Array,
       skip_defaults: [TrueClass, FalseClass],


### PR DESCRIPTION
We are using the gem for some sizable exports, and It would be beneficial if the package would accept Enumerators.  That opens up some better optimization paths.  

For example, in rails, we could do the following.

`EventsWriter.to_xslx( instances: Event.where(...).find_each )`

This would then optimize the retrieval side for significant exports with little effort.  I'm happy to make this PR more complete if you're interested in the idea.