### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ class PostsController < ActionController::Base
       format.html
       format.xlsx { render xlsx: @posts.to_xlsx(headers: false) }
       format.ods { render ods: Post.to_ods(instances: @posts) }
-      format.csv{ render csv: @posts.to_csv(headers: false), file_name: 'articles' }
+      format.csv{ render csv: @posts.to_csv(headers: false), filename: 'articles' }
     end
   end
 end


### PR DESCRIPTION
I noticed this typo while reading the [Method 2: Send Data via Rails Controller](https://github.com/westonganger/spreadsheet_architect#method-2-send-data-via-rails-controller) part of the `README` so I wrote a small PR to fix it.

The last example uses the key `:file_name` when the correct key is `:filename`.