### PR TITLE
Accept csv generate options hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Same options as `to_ods`
 |**instances**<br>*Array*| |Cannot be used with the `:data` option.<br><br>Array of class/model instances to be used as row data. Cannot be used with :data option|
 |**spreadsheet_columns**<br>*Proc/Symbol/String*| Use this option to override or define the spreadsheet columns. Normally, if this option is not specified and are using the instances option/ActiveRecord relation, it uses the classes custom `spreadsheet_columns` method or any custom defaults defined.<br>If neither of those and is an ActiveRecord model, then it will falls back to the models `self.column_names` | Cannot be used with the `:data` option.<br><br>If a Proc value is passed it will be evaluated on the instance object.<br><br>If a Symbol or String value is passed then it will search the instance for a method name that matches and call it. |
 |**headers**<br>*Array / 2D Array*| |Data for the header row cells. If using on a class/relation, this defaults to the ones provided via `spreadsheet_columns`. Pass `false` to skip the header row. |
+|**csv_generate_options**<br>*Hash*|{}|Options passed down to `CSV.generate` method. See ["Options for generating"](https://ruby-doc.org/3.2.1/stdlibs/csv/CSV.html#class-CSV-label-Options+for+Generating) paragraph on the official doc for reference |
 
 
 # Change class-wide default method options

--- a/lib/spreadsheet_architect/class_methods/csv.rb
+++ b/lib/spreadsheet_architect/class_methods/csv.rb
@@ -7,13 +7,13 @@ module SpreadsheetArchitect
       opts = SpreadsheetArchitect::Utils.get_options(opts, self)
       options = SpreadsheetArchitect::Utils.get_cell_data(opts, self)
 
-      CSV.generate do |csv|
+      CSV.generate(**opts.fetch(:csv_generate_options, {})) do |csv|
         if options[:headers]
           options[:headers].each do |header_row|
             csv << header_row
           end
         end
-        
+
         options[:data].each do |row_data|
           csv << row_data
         end

--- a/lib/spreadsheet_architect/utils.rb
+++ b/lib/spreadsheet_architect/utils.rb
@@ -30,7 +30,7 @@ module SpreadsheetArchitect
 
       if !data
         if !options[:instances]
-          if is_ar_model?(klass) 
+          if is_ar_model?(klass)
             options[:instances] = klass.where(nil).to_a # triggers the relation call, not sure how this works but it does
           else
             raise SpreadsheetArchitect::Exceptions::NoDataError
@@ -266,6 +266,7 @@ module SpreadsheetArchitect
       spreadsheet_columns: [Proc, Symbol, String],
       escape_formulas: [TrueClass, FalseClass, Array],
       use_zero_based_row_index: [TrueClass, FalseClass],
+      csv_generate_options: Hash
     }.freeze
 
   end


### PR DESCRIPTION
## Problem

As far as I understood, it's not possible to configure how the csv file will be generated.

My personal use case is to be able to export a CSV with custom column separator.

## Proposal

Introduce a new option called `csv_generate_options`; this is a `Hash. This will be passed down to the `CSV.generate` call, thus accepted options are the same as ones accepted by the `CSV` class.

Here's the ref: https://ruby-doc.org/3.2.1/stdlibs/csv/CSV.html#class-CSV-label-Options+for+Generating

The option will be configurable as other options are:

- `csv_generate_options` parameter passed to `.to_csv` method
- `SPREADSHEET_OPTIONS` global config
- `SpreadsheetArchitect.default_options` global config
