### PR TITLE
Use --enable-frozen-string-literal in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,4 +59,4 @@ jobs:
     - name: Run test
       run: |
         bundle install
-        bundle exec rake test
+        RUBYOPT='--enable-frozen-string-literal' bundle exec rake test


### PR DESCRIPTION
Seems to me that the wisest approach to this is that the CI checks compatibility with frozen string literals, rather than mucking around with this magic comment in every file. Ruby itself should make this decision to switch.