### PR TITLE
Add csv gem as gemspec dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 ---------
 
 - **Unreleased** - [View Diff](https://github.com/westonganger/spreadsheet_architect/compare/v5.0.1...master)
-  - Nothing yet
+  - [#64](https://github.com/westonganger/spreadsheet_architect/pull/64) - Explicitly list `csv` gem as a dependency to better support Ruby 3.4
 
 - **v5.0.1** - [View Diff](https://github.com/westonganger/spreadsheet_architect/compare/v5.0.0...v5.0.1)
   - [#53](https://github.com/westonganger/spreadsheet_architect/pull/53) - Remove legacy string_width patch for axlsx 3.1 and below

--- a/spreadsheet_architect.gemspec
+++ b/spreadsheet_architect.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'caxlsx', ['>= 3.3.0', '<4']
   s.add_runtime_dependency 'rodf', ['>= 1.0.0', '<2']
+  s.add_runtime_dependency 'csv'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'


### PR DESCRIPTION
Starting Ruby 3.4 you must explicitly list `csv` as a dependency, but its also compatible to do that with all older Ruby versions