### PR TITLE
Disable assertionless tests warning

### DIFF
--- a/test/dummy_app/config/application.rb
+++ b/test/dummy_app/config/application.rb
@@ -44,9 +44,5 @@ module Dummy
     config.after_initialize do
       ActiveRecord::Migration.migrate(Rails.root.join("db/migrate/*").to_s)
     end
-
-    if config.respond_to?(:assertionless_tests_behavior)
-      config.assertionless_tests_behavior = :ignore
-    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,10 @@ Warning.ignore(
   %r{mail/parsers/address_lists_parser}, ### Hide mail gem warnings
 )
 
+Warning.ignore(
+  %r{Test is missing assertions:}
+)
+
 require File.expand_path("../dummy_app/config/environment.rb",  __FILE__)
 
 migration_path = Rails.root.join('db/migrate')


### PR DESCRIPTION
Previous change failed #65 

Turns out the Rails configuration option was removed

https://github.com/rails/rails/commit/6a6c7e64f5bbea9b66c8b93eb85278805c2700a1#diff-69fc8a8270c5c3b28643754d2918a628b24bb615883bf25ac052f2ccecdb9177R16