### PR TITLE
Update caxlsx, relax rodf version dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 ---------
 
 - **Unreleased** - [View Diff](https://github.com/westonganger/spreadsheet_architect/compare/v5.0.1...master)
+  - [#68](https://github.com/westonganger/spreadsheet_architect/pull/68) - Require `caxlsx` v4.0 or greater (to support frozen_string_literal) and remove version locking for `rodf`
   - [#64](https://github.com/westonganger/spreadsheet_architect/pull/64) - Explicitly list `csv` gem as a dependency to better support Ruby 3.4
 
 - **v5.0.1** - [View Diff](https://github.com/westonganger/spreadsheet_architect/compare/v5.0.0...v5.0.1)

--- a/spreadsheet_architect.gemspec
+++ b/spreadsheet_architect.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("{lib/**/*}") + %w{ LICENSE README.md Rakefile CHANGELOG.md }
   s.require_path = 'lib'
 
-  s.add_runtime_dependency 'caxlsx', ['>= 3.3.0', '<4']
-  s.add_runtime_dependency 'rodf', ['>= 1.0.0', '<2']
+  s.add_runtime_dependency 'caxlsx', '<= 4.0'
+  s.add_runtime_dependency 'rodf'
   s.add_runtime_dependency 'csv'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
- Use caxlsx >= 4.0 to ensure frozen string literal support
- Remove rodf dependency version locking to avoid similar future issues with upgrades